### PR TITLE
Create Clean Publish Branch

### DIFF
--- a/.github/workflows/gh_actions.yml
+++ b/.github/workflows/gh_actions.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Generate Documentation
         run: |
-          cp Doxyfile MAIN_PAGE.md ./Lean
+          cp Doxyfile MAIN_PAGE.md ./custom-styles/style.css ./Lean
           cd Lean
           doxygen
           cd ..
@@ -35,12 +35,15 @@ jobs:
           mv -f ./_docs/mag_sel.png ./_docs/search/
           rm -r Lean
 
-      - name: Commit and Push
+      - name: Delete Current "published" Branch
         run: |-
           git config --global user.email "actions@users.noreply.github.com"
           git config --global user.name "GitHub Actions"
-          git fetch origin
-          git checkout -f published
+          git push origin --delete published
+
+      - name: Commit and Push
+        run: |-
+          git checkout -b published
           git add -A
           git commit --allow-empty -m "Updates Documentation"
           git push origin published -f

--- a/.github/workflows/gh_actions_daily_release.yml
+++ b/.github/workflows/gh_actions_daily_release.yml
@@ -57,6 +57,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./Lean/documentation.zip
+          asset_path: ./documentation.zip
           asset_name: documentation.zip
           asset_content_type: application/zip


### PR DESCRIPTION
Delete the current `publish` branch, then create a new one with the same name to ensure a clean branch to receive the documentation.